### PR TITLE
Require numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 libsigopt @ git+http://github.com/sigopt/libsigopt@19d481b58b7f18f7bcd4fdfff87da7c0eadf5a62
+numpy>=1.22.4,<1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 libsigopt @ git+http://github.com/sigopt/libsigopt@19d481b58b7f18f7bcd4fdfff87da7c0eadf5a62
-numpy>=1.22.4,<1.23
+numpy>=1.22.4,<2


### PR DESCRIPTION
We should add numpy to requirements.txt since it's used here. My mistake when cutting this repo over.