### PR TITLE
Update checkout to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: pip install --upgrade pip setuptools
       - run: pip install . -r requirements-dev.txt
       - run: git ls-files '*.py' | xargs pylint --output-format=text -sn
@@ -25,7 +25,7 @@ jobs:
       NUMEXPR_NUM_THREADS: "1"
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: |
           set -e
           curl -fSsLo trivy.deb https://github.com/aquasecurity/trivy/releases/download/v0.38.3/trivy_0.38.3_Linux-64bit.deb


### PR DESCRIPTION
Looks like the big difference is that checkout v4 uses node20 rather than node16 by default. Figured we could just run this and see that it works rather than stick with checkout v3 and force it onto node20. 